### PR TITLE
Format number output in print_tokens

### DIFF
--- a/chatblade/printer.py
+++ b/chatblade/printer.py
@@ -22,8 +22,8 @@ def print_tokens(messages, token_count, args):
     table.add_column("Measure", no_wrap=True)
     table.add_column("Value", style="bold", justify="right")
     table.add_row("Tokens", f"{token_count}")
-    table.add_row("GPT 3.5", f"${0.002 * token_count / 1000}")
-    table.add_row("GPT 4", f"~ ${0.045 * token_count / 1000}")
+    table.add_row("GPT 3.5", '${:.6f}'.format(0.002 * token_count / 1000))
+    table.add_row("GPT 4", '~ ${:.6f}'.format(0.045 * token_count / 1000))
     console.print(table)
 
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/5457202/226564834-c1d5703c-d41d-4f61-969f-eef2a707e3f9.png)
After:
![image](https://user-images.githubusercontent.com/5457202/226564978-347d4fb6-c01a-4298-a773-5b09723e4a0e.png)

Six decimal points is chosen because GPT3.5 costs 2*10^-6/token