### PR TITLE
Add argument "-b" for breathing exercise while waiting for API response

### DIFF
--- a/chatblade/cli.py
+++ b/chatblade/cli.py
@@ -1,12 +1,20 @@
 import sys
 import rich
+import threading
 from rich.prompt import Prompt
 
 from . import printer, chat, utils, storage, errors, parser
 
 
 def fetch_and_cache(messages, params):
+    if params["breathe"]:
+        stopper = threading.Event()
+        thread = threading.Thread(target=utils.breathing, args=[stopper])
+        thread.start()
     response_msg, _ = chat.query_chat_gpt(messages, params)
+    if params["breathe"]:
+        stopper.set()
+        thread.join()
     messages.append(response_msg)
     storage.to_cache(messages)
     return messages

--- a/chatblade/parser.py
+++ b/chatblade/parser.py
@@ -108,6 +108,12 @@ def parse(args):
         help="display what *would* be sent, how many tokens, and estimated costs",
         action="store_true",
     )
+    parser.add_argument(
+        "-b",
+        "--breathe",
+        help="Do 4-7-8 breathing exercise when waiting for the API reply",
+        action="store_true",
+    )
 
     # --- debug
     parser.add_argument("--debug", action="store_true", help=argparse.SUPPRESS)

--- a/chatblade/utils.py
+++ b/chatblade/utils.py
@@ -1,3 +1,6 @@
+import time
+from itertools import cycle
+from rich.progress import Progress
 from rich.pretty import pprint
 
 CONSOLE_DEBUG_LOGGING = False
@@ -24,3 +27,26 @@ def debug(title=None, **kwargs):
             pprint({f"{title}": kwargs})
         else:
             pprint(kwargs)
+
+
+def breathing(stopper):
+    breathing_phases = [
+	["[blue]Inhale...", 400],
+	["[green]Hold.....", 700],
+	["[blue]Exhale...", 800],
+    ]
+
+    for i in cycle(breathing_phases):
+        p = Progress(transient=True)
+        p.columns[2].text_format = ""
+
+        with p as progress:
+            task = progress.add_task(i[0], total=i[1])
+            while not progress.finished:
+                if stopper.is_set():
+                    break
+                progress.update(task, advance=10)
+                time.sleep(0.1)
+            if stopper.is_set():
+                break
+


### PR DESCRIPTION
I really like chatblade, but I find myself starting at the terminal while waiting for the response for tens of seconds. I thought that I could use the waiting time for something beneficial. I though of breathing exercise, and I chuckled on the idea. Then I thought why not.

This PR adds the possibility to show a [4-7-8 seconds breathing exercise](https://pubmed.ncbi.nlm.nih.gov/36480101/) while waiting for the response. It tells the user to inhale for 4 seconds, then hold for 7 seconds and then exhale for 8 seconds.

https://asciinema.org/a/wtBnFUsgkbpqtAVqYHklQEtp1
