### PR TITLE
Azure support - use same ENV names as python-openai

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,8 @@ chatblade -l -e > toanki
 
 chatblade can be used with an Azure OpenAI endpoint, in which case in addition to the `OPENAI_API_KEY` you'll need to set the following environment variables:
 
-- `OPENAI_API_ENDPOINT` :: URL to your cognitive services endpoint, e.g. `https://eastus.api.cognitive.microsoft.com/`
+- `OPENAI_API_TYPE` :: Set to `azure`. As required by [openai-python](https://github.com/openai/openai-python)
+- `OPENAI_API_BASE` :: URL to your cognitive services endpoint, e.g. `https://eastus.api.cognitive.microsoft.com/`
 - `OPENAI_API_AZURE_ENGINE` :: name of your deployment in Azure, eg `my-gpt-35-turbo` (maps to a specific model)
 
 *Note*: that this will override any option for `-c 3.5` or `-c 4` which don't make sense in this case.

--- a/chatblade/chat.py
+++ b/chatblade/chat.py
@@ -81,19 +81,14 @@ def map_single(result):
 
 
 def set_azure_if_present(config):
-    """checks if azure settings present and sets them"""
-    if "OPENAI_API_ENDPOINT" in os.environ:
-        openai.api_base = os.environ["OPENAI_API_ENDPOINT"]
-        if "microsoft.com" in os.environ["OPENAI_API_ENDPOINT"]:
-            openai.api_type = "azure"
-            openai.api_version = "2023-03-15-preview"
-        else:
-            raise errors.ChatbladeError(
-                "Unknown opeanai endpoint. Currently only azure is supported"
-            )
+    """checks if azure settings present and sets endpoint config."""
+    if os.environ.get("OPENAI_API_TYPE", "open_ai") in ("azure", "azure_ad", "azuread"):
+        # this is a workaround that can be removed once https://github.com/openai/openai-python/pull/335
+        # is in the openai version that chatblade uses
+        openai.api_version = "2023-03-15-preview"
+
     if "OPENAI_API_AZURE_ENGINE" in os.environ:
         config["engine"] = os.environ["OPENAI_API_AZURE_ENGINE"]
-
 
 def query_chat_gpt(messages, config):
     """Queries the chat GPT API with the given messages and config."""


### PR DESCRIPTION
This makes chatblade use the same ENV variables that openai-python already supports:
  - rename `OPENAI_API_ENDPOINT` to `OPENAI_API_BASE`
  - add additional required `OPENAI_API_TYPE=azure`. 

Note that the engine name setting is still required. 

Comment on chat.py:84 -- In the current openai the default openai.api_version does not work with the Chat API on azure, so need to override. Once https://github.com/openai/openai-python/pull/335 is released that workaround can be removed, and we only need the engine setting.