### PR TITLE
Allow custom OpenAI API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ And since we asked for JSON, we can pipe our result to something else, e.g.:
 chatblade -l -e > toanki
 ```
 
+### Configuring for OpenAI API Proxy
+
+If you have set up a proxy server for the OpenAI API at `https://api.example.com`, you'll need to set the following environment variables:
+
+- `OPENAI_API_ENDPOINT` :: URL to your cognitive services endpoint with version path, e.g. `https://api.example.com/v1`
+
 ### Configuring for Azure OpenAI
 
 chatblade can be used with an Azure OpenAI endpoint, in which case in addition to the `OPENAI_API_KEY` you'll need to set the following environment variables:

--- a/chatblade/chat.py
+++ b/chatblade/chat.py
@@ -87,10 +87,6 @@ def set_azure_if_present(config):
         if "microsoft.com" in os.environ["OPENAI_API_ENDPOINT"]:
             openai.api_type = "azure"
             openai.api_version = "2023-03-15-preview"
-        else:
-            raise errors.ChatbladeError(
-                "Unknown opeanai endpoint. Currently only azure is supported"
-            )
     if "OPENAI_API_AZURE_ENGINE" in os.environ:
         config["engine"] = os.environ["OPENAI_API_AZURE_ENGINE"]
 


### PR DESCRIPTION
My company does not allow direct access to the external network, so I created a reverse proxy for the OpenAI API on the gateway machine. Therefore, it is necessary to allow custom OpenAI API endpoints.