### PR TITLE
Adding option to only print answer

### DIFF
--- a/chatblade/parser.py
+++ b/chatblade/parser.py
@@ -114,6 +114,12 @@ def parse(args):
         help="display what *would* be sent, how many tokens, and estimated costs",
         action="store_true",
     )
+    parser.add_argument(
+        "-o",
+        "--only",
+        help="Only display the response, omit query",
+        action="store_true",
+    )
 
     # --- debug
     parser.add_argument("--debug", action="store_true", help=argparse.SUPPRESS)

--- a/chatblade/printer.py
+++ b/chatblade/printer.py
@@ -18,7 +18,10 @@ def warn(msg):
 
 
 def print_tokens(messages, token_stats, args):
-    args.roles = ["user", "assistant", "system"]
+    if args.only:
+      args.roles = ["assistant"]
+    else:
+      args.roles = ["user", "assistant", "system"]
     print_messages(messages, args)
     console.print()
     table = Table(title="tokens/costs")
@@ -39,6 +42,9 @@ def print_tokens(messages, token_stats, args):
 
 def print_messages(messages, args):
     if "roles" not in args:
+      if args.only:
+        args.roles = ["assistant"]
+      else:
         args.roles = ["user", "assistant"]
     if args.extract:
         extract_messages(messages, args)


### PR DESCRIPTION
Adding option to only print the answer, omitting the user query. 
Useful if you want to pipe the answer to any other program, but can't extract via -e. 
E.g. if you want to push some text in to a Excel sheet.