### PR TITLE
Introduce no format option

### DIFF
--- a/chatblade/parser.py
+++ b/chatblade/parser.py
@@ -114,6 +114,12 @@ def parse(args):
         help="display what *would* be sent, how many tokens, and estimated costs",
         action="store_true",
     )
+    parser.add_argument(
+        "-n",
+        "--no-format",
+        help="do not add pretty print formatting to output",
+        action="store_true",
+    )
 
     # --- debug
     parser.add_argument("--debug", action="store_true", help=argparse.SUPPRESS)

--- a/chatblade/printer.py
+++ b/chatblade/printer.py
@@ -57,14 +57,16 @@ def print_message(message, args):
         printable = detect_and_format_message(
             message.content, cutoff=1000 if message.role == "user" else None
         )
-    console.print(Rule(message.role, style=COLORS[message.role]))
+    if not args.no_format:
+      console.print(Rule(message.role, style=COLORS[message.role]))
 
     if args.raw:
         print(message.content)
     else:
         console.print(printable)
 
-    console.print(Rule(style=COLORS[message.role]))
+    if not args.no_format:
+      console.print(Rule(style=COLORS[message.role]))
 
 
 def extract_messages(messages, args):


### PR DESCRIPTION
Introducing no-format, which forgoes the pretty print of the usual invocation of chatblade. 
Useful if you want to have cleaner output, e.g. for piping in to another command.