### PR TITLE
Introducing directory parameter

### DIFF
--- a/chatblade/cli.py
+++ b/chatblade/cli.py
@@ -22,7 +22,7 @@ def fetch_and_cache(messages, params):
     else:
         response_msg = chat.query_chat_gpt(messages, params)
     messages.append(response_msg)
-    storage.to_cache(messages)
+    storage.to_cache(messages, params)
     return messages
 
 

--- a/chatblade/parser.py
+++ b/chatblade/parser.py
@@ -114,6 +114,12 @@ def parse(args):
         help="display what *would* be sent, how many tokens, and estimated costs",
         action="store_true",
     )
+    parser.add_argument(
+        "--directory",
+        metavar="d",
+        type=str,
+        help="Set the chatblade cache location (default ~/.cache/chatblade, ~/Library/Caches/chatblade on osx)",
+    )
 
     # --- debug
     parser.add_argument("--debug", action="store_true", help=argparse.SUPPRESS)

--- a/chatblade/storage.py
+++ b/chatblade/storage.py
@@ -13,13 +13,19 @@ from . import errors
 APP_NAME = "chatblade"
 
 
-def get_cache_file_path():
+def get_cache_file_path(args):
     """
     if ~/.cache is availabe always use ~/.cache/chatblade as the cachefile
     otherwise fallback to the platform recommended location and create the directory
     e.g. ~/Library/Caches/chatblade on osx
     """
-    cache_path = os.path.expanduser("~/.cache")
+    if "directory" not in args:
+      cache_path = os.path.expanduser("~/.cache")
+    else:
+      cache_path = os.path.expanduser(args.directory)
+      if not os.path.exists(cache_path):
+        os.makedirs(cache_path)
+
     if not os.path.exists(cache_path):
         cache_path = platformdirs.user_cache_dir(APP_NAME)
         if not os.path.exists(cache_path):
@@ -28,9 +34,9 @@ def get_cache_file_path():
     return os.path.join(cache_path, APP_NAME)
 
 
-def to_cache(messages):
+def to_cache(messages, args):
     """cache the current messages state"""
-    with open(get_cache_file_path(), "wb") as f:
+    with open(get_cache_file_path(args), "wb") as f:
         pickle.dump(messages, f)
 
 


### PR DESCRIPTION
Giving the user the choice where to store the cache, useful if you e.g. have chatblade set as part of a pipeline which only has limited access and the default is not working.