### PR TITLE
chore: pin openai dependency version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,8 +12,8 @@ project_urls =
 
 [options]
 packages = chatblade
-install_requires = 
-  openai>=0.27.2
+install_requires =
+  openai~=0.27.2
   tiktoken
   rich
   pyyaml


### PR DESCRIPTION
Hey @npiv,

OpenAI released a new major version (1.0.0) 2 days ago. This came with breaking changes. Pinning the specific version to only accept new minor or patch versions will solve this issue.

One can test this by pulling down this commit and performing a new install via:

`$ python -m pip install .`

Otherwise, you'll run into:

```
import openai.error
ModuleNotFoundError: No module named 'openai.error'
```