### PR TITLE
fix: azure deployment name not read

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ chatblade -l -e > toanki
 chatblade can be used with an Azure OpenAI endpoint, in which case in addition to the `OPENAI_API_KEY` you'll need to set the following environment variables:
 
 - `OPENAI_API_TYPE` :: Set to `azure`. As required by [openai-python](https://github.com/openai/openai-python)
-- `OPENAI_API_BASE` :: URL to your cognitive services endpoint, e.g. `https://eastus.api.cognitive.microsoft.com/`
+- `AZURE_OPENAI_ENDPOINT` :: URL to your cognitive services endpoint, e.g. `https://eastus.api.cognitive.microsoft.com/`. Please note this is a *breaking change* introduced by `openai-python` and the previous environment variable name is `OPENAI_API_BASE`
 - `OPENAI_API_AZURE_ENGINE` :: name of your deployment in Azure, eg `my-gpt-35-turbo` (maps to a specific model)
 
 *Note*: that this will override any option for `-c 3.5` or `-c 4` which don't make sense in this case.

--- a/chatblade/chat.py
+++ b/chatblade/chat.py
@@ -107,7 +107,10 @@ def map_single(result):
 
 def build_client(config):
     if "OPENAI_API_AZURE_ENGINE" in os.environ:
-        return openai.AzureOpenAI(api_key=config["openai_api_key"])
+        return openai.AzureOpenAI(
+            api_key=config["openai_api_key"],
+            azure_deployment=os.environ.get("OPENAI_API_AZURE_ENGINE"),
+        )
     else:
         return openai.OpenAI(api_key=config["openai_api_key"])
 


### PR DESCRIPTION
Since the release of `openai-python 1.0`, breaking changes were introduced for azure openai client creation. So the deployment name needs to be passed and `OPENAI_API_BASE` should be changed into `AZURE_OPENAI_ENDPOINT` for it to be read by `openai-python`.