### PR TITLE
fix: remove redundant semicolon in query prompt

### DIFF
--- a/chatblade/cli.py
+++ b/chatblade/cli.py
@@ -30,7 +30,7 @@ def fetch_and_cache(messages, params):
 def start_repl(messages, params):
     while True:
         try:
-            query = Prompt.ask("[yellow]query (type 'quit' to exit): [/yellow]")
+            query = Prompt.ask("[yellow]query (type 'quit' to exit)[/yellow]")
         except (EOFError, KeyboardInterrupt):
             rich.print("\n")
             exit()


### PR DESCRIPTION
In `rich`, `Prompt.ask` seems to be [already including](https://github.com/Textualize/rich/blob/fd981823644ccf50d685ac9c0cfe8e1e56c9dd35/rich/prompt.py#L49) a `prompt_suffix` (`: `), so the `: ` here might not be needed.