### PR TITLE
feat: option to limit the number of conversations passed

### DIFF
--- a/chatblade/cli.py
+++ b/chatblade/cli.py
@@ -56,7 +56,10 @@ def handle_input(query, params):
 
     messages = None
     if params.session:
-        messages = storage.messages_from_cache(params.session)
+        if params.conversation_limit:
+            messages = storage.messages_from_cache(params.session)[-params.conversation_limit:]
+        else:
+            messages = storage.messages_from_cache(params.session)
     if messages:  # a session specified and it alredy exists
         if params.prompt_file:
             printer.warn("refusing to prepend prompt to existing session")

--- a/chatblade/parser.py
+++ b/chatblade/parser.py
@@ -149,6 +149,12 @@ def parse(args):
         action="store_true",
     )
     parser.add_argument(
+        "-cl",
+        "--conversation-limit",
+        help="limit the number of conversations passed with a session",
+        action="store_true",
+    )
+    parser.add_argument(
         "-p",
         "--prompt-file",
         metavar="name",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = chatblade
-version = 0.3.4
+version = 0.3.5
 description = CLI Swiss Army Knife for ChatGPT
 long_description = file: README.md
 long_description_content_type=text/markdown


### PR DESCRIPTION
Adding an option to limit the number of conversations being sent with the session. Fixes the problem of going over the token limit when using a session over time.

Feedback is welcome!