### PR TITLE
Add default prompt via env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ This won't perform any action over the wire, and just calculates the tokens loca
 
 The system message is used to instruct the model how to behave, see [OpenAI - Instructing Chat Models](https://platform.openai.com/docs/guides/chat/instructing-chat-models).
 
-These can be loaded with `-p`. For convenience any file we place under ~/.config/chatblade/ will be picked up by this command.
+These can be loaded with `-p`. For convenience any file we place under `~/.config/chatblade/` will be picked up by this command.
 
 So for example, given the following file `~/.config/chatblade/etymology`, which contains:
 
@@ -200,7 +200,13 @@ We can now run a command and refer to this prompt with `-p etymology`:
 chatblade -p etymology gregarious
 ```
 
-You can also point -p to a file path directly to load a system message from any arbitrary location
+If you set the environment variable `CHATBLADE_DEFAULT_PROMPT` to the name of a prompt, chatblade will use its value if no other prompt is specified on the command line.
+```bash
+% export CHATBLADE_DEFAULT_PROMPT=default
+% chatblade "Hi there"  # Acts like -p default
+```
+
+You can also point `-p` to a file path directly to load a system message from any arbitrary location
 
 <img src="assets/example5.png">
 

--- a/chatblade/cli.py
+++ b/chatblade/cli.py
@@ -143,6 +143,13 @@ def cli():
     migrate_old_cache_file_if_exists()
 
     query, params = parser.parse(sys.argv[1:])
+
+    # If we don't have a prompt on the command line, but the user has
+    # defined a CHATBLADE_DEFAULT_PROMPT environment variable, use the env
+    # variable as the prompt.
+    if not params.prompt_file and "CHATBLADE_DEFAULT_PROMPT" in os.environ:
+        params.prompt_file = os.environ["CHATBLADE_DEFAULT_PROMPT"]
+
     if params.session_op:
         ret = do_session_op(params.session, params.session_op, params.rename_to)
         exit(ret)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = chatblade
-version = 0.3.4
+version = 0.3.5
 description = CLI Swiss Army Knife for ChatGPT
 long_description = file: README.md
 long_description_content_type=text/markdown


### PR DESCRIPTION
This PR adds support for having chatblade use a default prompt. The default is set via an environment variable. In some ways, it makes chatblade similar to ChatGPT's "custom instructions" that are automatically applied for all new chats.

- If CHATBLADE_DEFAULT_PROMPT is set in the user's environment, use the prompt set there as if it had been specified on the command line with -p.  If the user has "-p prompt" on the command line, use that instead of the environment variable.
- Bump version number