### PR TITLE
Fix typo in metavar name

### DIFF
--- a/chatblade/parser.py
+++ b/chatblade/parser.py
@@ -112,7 +112,7 @@ def parse(args):
     )
     parser.add_argument(
         "--openai-base-url",
-        metavar="key",
+        metavar="url",
         type=str,
         help="A custom url to use the openAI against a local or custom model, eg ollama",
     )


### PR DESCRIPTION
`chatblade --help`
```
usage: Chatblade [-h] [--openai-api-key key] [--openai-base-url key] [--temperature t] [-c CHAT_GPT] [-i] [-s] [-t] [--version] [-p name] [-e] [-r] [-n] [-o]
                 [--theme theme] [-l] [-S sess] [--session-list] [--session-path] [--session-dump] [--session-delete] [--session-rename newsess]
                 [query ...]

a CLI Swiss Army Knife for ChatGPT

positional arguments:
  query                            Query to send to chat GPT

options:
  -h, --help                       show this help message and exit
  --openai-api-key key             the OpenAI API key can also be set as env variable OPENAI_API_KEY
  --openai-base-url key            A custom url to use the openAI against a local or custom model, eg ollama
```

`key` => `url`