### PR TITLE
feat: convert latex to plain text

### DIFF
--- a/chatblade/printer.py
+++ b/chatblade/printer.py
@@ -9,6 +9,7 @@ from rich.table import Table
 from rich.rule import Rule
 
 from chatblade import utils
+from pylatexenc.latex2text import LatexNodes2Text
 
 
 console = Console()
@@ -85,8 +86,20 @@ def extract_messages(messages, args):
     else:
         print(message.content.strip())
 
+def format_latex(msg):
+    converter = LatexNodes2Text()
+    msg = converter.latex_to_text(msg)
+
+    # do no change code blocks to smart quotes, this will break the markdown
+    # parser.
+    msg = msg.replace("“", "``")
+
+    return msg
 
 def detect_and_format_message(msg, cutoff=None, theme=None):
+    # convert any latex markup to ASCII.
+    msg = format_latex(msg)
+
     if cutoff and len(msg) > cutoff:
         msg = "... **text shortened** ... " + msg[-cutoff:]
         return msg

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ platformdirs==4.2.2
 pydantic==2.8.2
 pydantic_core==2.20.1
 Pygments==2.18.0
+pylatexenc==2.10
 PyYAML==6.0.1
 regex==2024.5.15
 requests==2.32.3


### PR DESCRIPTION
Newest GPT models love to provide latex markup.

Unfortunately this makes things pretty impossible to read for larger questions.

Add a conversion to change latex markup to plain text.

Closes  #87

Before:

```
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── user ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
show me a gamma correction formula
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── assistant ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Gamma correction is a nonlinear operation used to encode and decode luminance or tristimulus values in image processing. The formula for gamma correction can be expressed as follows:

For a pixel value \( I \) (where \( I \) is typically in the range [0, 1] or [0, 255]), the gamma corrected value \( I_{\text{corrected}} \) is given by:

[
I_{\text{corrected}} = I^{\gamma}
\]

Where:
- \( I \) is the original pixel value (normalized to [0, 1] if necessary).
- \( \gamma \) is the gamma value (a positive real number). A common value for gamma is 2.2.

If the pixel values are in the range [0, 255], the formula can be adjusted as follows:

[
I_{\text{corrected}} = 255 \times \left( \frac{I}{255} \right)^{\gamma}
\]

In this case, you first normalize the pixel value by dividing by 255, apply the gamma correction, and then scale it back to the original range.

### Inverse Gamma Correction

To reverse the gamma correction (to get back the original pixel value), you can use the inverse formula:

[
I_{\text{original}} = I_{\text{corrected}}^{\frac{1}{\gamma}}
\]

This allows you to retrieve the original pixel value from the gamma-corrected value.
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```

After:

```
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── user ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
show me a gamma correction formula
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── assistant ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Gamma correction is a nonlinear operation used to encode and decode luminance or tristimulus values in image processing. The formula for gamma correction can be expressed as follows:

For a pixel value I (where I is typically in the range [0, 1] or [0, 255]), the gamma corrected value I_corrected is given by:


    I_corrected = I^γ


Where:
- I is the original pixel value (normalized between 0 and 1).
- γ is the gamma value (a positive real number). A common value for γ is around 2.2 for standard displays.

If the pixel values are in the range [0, 255], the formula can be adjusted as follows:


    I_corrected = 255 ×( I/255)^γ


In this case, you first normalize the pixel value by dividing by 255, apply the gamma correction, and then scale it back to the original range.

### Inverse Gamma Correction
To reverse the gamma correction (to get back the original pixel value), you can use the inverse formula:


    I_original = I_corrected^1/γ


This allows you to retrieve the original pixel value from the gamma-corrected value.
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```