### PR TITLE
Remove distutils usage for Python 3.12 compatibility

### DIFF
--- a/chatblade/cli.py
+++ b/chatblade/cli.py
@@ -149,11 +149,8 @@ def cli():
     if params.debug:
         utils.CONSOLE_DEBUG_LOGGING = True
     if params.version:
-        from distutils.dist import Distribution
-        dist = Distribution()
-        dist.parse_config_files()
-        version = dist.get_option_dict('metadata')['version'][1]
-        print(f"chatblade {version}")
+        from importlib.metadata import version as get_version
+        print(f"chatblade {get_version('chatblade')}")
         exit(0)
     try:
         handle_input(query, params)

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ project_urls =
 
 [options]
 packages = chatblade
+python_requires = >=3.8
 install_requires =
   openai~=1.35.15
   tiktoken~=0.7.0


### PR DESCRIPTION
The distutils module was removed from the standard library in Python 3.12 [0]. Replace it with importlib.metadata, introduced in Python 3.8 [1] and set that as the minimum required Python version.

Without this change, the following error occurs on Python 3.12:

    $ chatblade --version
    Traceback (most recent call last):
      File "/usr/bin/chatblade", line 8, in <module>
        sys.exit(main())
                 ^^^^^^
      File "/usr/lib/python3.12/site-packages/chatblade/__main__.py", line 5, in main
        cli.cli()
      File "/usr/lib/python3.12/site-packages/chatblade/cli.py", line 155, in cli
        version = dist.get_option_dict('metadata')['version'][1]
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
    KeyError: 'version'

Let me know if you want compatibility with older versions than Python 3.8 and I'll wrap this in a try catch and use what's available.

[0]: https://docs.python.org/3/whatsnew/3.12.html#distutils
[1]: https://docs.python.org/3/whatsnew/3.8.html#new-modules