### PR TITLE
Removed formatting on latex comments to prevent % characters from removing lines of text

### DIFF
--- a/chatblade/printer.py
+++ b/chatblade/printer.py
@@ -96,7 +96,7 @@ def format_latex(msg):
     code_inlines = re.findall(code_inline_pattern, msg)
     msg = re.sub(code_inline_pattern, "\0CODE_INLINE\0", msg)
 
-    converter = LatexNodes2Text()
+    converter = LatexNodes2Text(keep_comments=True)
     msg = converter.latex_to_text(msg)
 
     # do no change code blocks to smart quotes, this will break the markdown


### PR DESCRIPTION
I noticed some requests with percentages ended up with blanks in them.

Because of latex parsing, any text following % is considered a comment and removed.

I think the obvious fix is to just not parse latex comments, which is provided with a simple option on the latex parser. I don't think parsing comments adds any functionality since it just removes output.

Before:
<img width="599" alt="image" src="https://github.com/user-attachments/assets/6359ddfa-400f-4c77-9945-ead9ea799c14">

After
<img width="566" alt="image" src="https://github.com/user-attachments/assets/1cf5f7b9-8221-42db-9ddc-ae71a1a5dc0e">
