### PR TITLE
chore: bump tiktoken to 0.8.0 to fix py3.13 build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ platformdirs==4.2.2
 pylatexenc==2.10
 PyYAML==6.0.1
 rich==13.7.1
-tiktoken==0.7.0
+tiktoken==0.8.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ packages = chatblade
 python_requires = >=3.8
 install_requires =
   openai~=1.35.15
-  tiktoken~=0.7.0
+  tiktoken~=0.8.0
   rich~=13.7.1
   PyYAML~=6.0.1
   platformdirs~=4.2.2
@@ -24,6 +24,3 @@ install_requires =
 [options.entry_points]
 console_scripts =
   chatblade = chatblade.__main__:main
-
-
-


### PR DESCRIPTION
👋 bump tiktoken to 0.8.0 to fix py3.13 build

relates to https://github.com/Homebrew/homebrew-core/pull/193878